### PR TITLE
Remove evReact dependency

### DIFF
--- a/Suave.EvReact.fs
+++ b/Suave.EvReact.fs
@@ -37,7 +37,7 @@ module EvReact =
         inherit ResponseEventArgs()
         member this.Context = h
 
-    let asyncTrigger (e:EvReact.Event<_>) args =
+    let asyncTrigger (e:Event<_>) args =
       async { e.Trigger(args) } |> Async.Start |> ignore
 
     let contentType t =
@@ -64,7 +64,7 @@ module EvReact =
       serializeJSON >> sendJson : _ -> unit
 
     let httpReact () =
-      let e = EvReact.Event()
+      let e = Event<_>()
       let webpart ctx =
         let args = HttpEventArgs(ctx)
         asyncTrigger e args
@@ -84,7 +84,7 @@ module EvReact =
       >=> handleJson handle <|> RequestErrors.BAD_REQUEST "Malformed data"
 
     let msgReact () =
-      let e = EvReact.Event()
+      let e = Event<_>()
       let handle x ctx =
         let msgCtx = MsgContext(ctx.request.url, ctx.connection.socketBinding)
         let args = MsgRequestEventArgs(msgCtx, x)
@@ -93,7 +93,7 @@ module EvReact =
       (jsonReact handle, e.Publish)
 
     let createRemoteIEvent () =
-      let e = EvReact.Event()
+      let e = Event<_>()
       let handle x =
         asyncTrigger e x
         Successful. OK ""

--- a/Suave.EvReact.fs
+++ b/Suave.EvReact.fs
@@ -37,8 +37,6 @@ module EvReact =
         inherit ResponseEventArgs()
         member this.Context = h
 
-    type HttpEvent = EvReact.Event<HttpEventArgs>
-
     let asyncTrigger (e:EvReact.Event<_>) args =
       async { e.Trigger(args) } |> Async.Start |> ignore
 

--- a/Suave.EvReact.fsproj
+++ b/Suave.EvReact.fsproj
@@ -58,10 +58,6 @@
     <Content Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="evReact">
-      <HintPath>packages\evReact.0.9.1\lib\net40\evReact.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="evReact" version="0.9.1" targetFramework="net452" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="Suave" version="1.1.3" targetFramework="net452" />


### PR DESCRIPTION
The library uses nothing in evReact besides the creation of `[I]Events`, which are also conveniently available from the F# core library.
The main additional advantage of using evReact was the guarantee that multiple accesses to the `Publish` properties would result in the same object, but the current API guarantees that this properties is accessed on each `Event` object exactly once.
